### PR TITLE
Add pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = BackendDev.settings


### PR DESCRIPTION
This config file should allow us to use the pytest-django plugin to create tests for Django similarly to how we would create them for other files. 
More info on this file can be found here: https://pytest-django.readthedocs.io/en/latest/#quick-start
Also here: https://docs.pytest.org/en/7.1.x/reference/customize.html#pytest-ini