### PR TITLE
Add icalendar to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ charset-normalizer==2.1.1
 colorama==0.4.5
 Django==4.1.1
 djangorestframework==3.14.0
+icalendar==5.0.1
 idna==3.4
 iniconfig==1.1.1
 joblib==1.1.0


### PR DESCRIPTION
Add icalendar to the requirements file for [this PR](https://github.com/cs261f22/BackendDev-repo/pull/19).
You will have to rerun `pip install -r requirements.txt` while in your venv in order to install this package.