### PR TITLE
Remove CalendarEvent model

### DIFF
--- a/data/models.py
+++ b/data/models.py
@@ -123,15 +123,6 @@ class Professor(models.Model):
     degree_desc = models.CharField(max_length=100)
 
 
-class CalendarEvent(models.Model):
-    name = models.CharField(max_length=100)
-    description = models.CharField(max_length=200)
-    organizer = models.CharField(max_length=100)
-    location = models.CharField(max_length=200)
-    startTime = models.CharField(max_length=100)
-    endTime = models.CharField(max_length=100)
-
-
 class AdminAssistant(models.Model):
     user = models.ForeignKey(
         Profile,


### PR DESCRIPTION
We only need one model for events, so we should remove one to reduce bloat.